### PR TITLE
variance, skewness and kurtosis of jitter of a session

### DIFF
--- a/features.js
+++ b/features.js
@@ -1078,7 +1078,7 @@ module.exports = {
 });
 
 // calculate central moment of jitter, assmuning it is a random variable.
-['googJitterBufferMs'].forEach(function(stat) {
+['googJitterBufferMs', 'googRtt'].forEach(function(stat) {
     module.exports['variance' + stat[0].toUpperCase() + stat.substr(1)] = function(client, peerConnectionLog) {
         return extractCentralMomentFromVideoStat(peerConnectionLog, stat, 2);
     };


### PR DESCRIPTION
video jitter. Probably need to refactor things a little to make it work for audio, too.

We need another layer of statistics obviously and look at mean and variance over all sessions.

I need to think about what those moments do with the linear increase in the playoutdelay we saw and how we can detect it that way.
