### PR TITLE
adds client and conference id features

### DIFF
--- a/features.js
+++ b/features.js
@@ -475,6 +475,16 @@ module.exports = {
             }
         }
     },
+    peerIdentifier: function(client, peerConnectionLog) {
+        var constraints = getPeerConnectionConstraints(peerConnectionLog) || [];
+        if (!constraints.optional) return;
+        constraints = constraints.optional;
+        for (var i = 0; i < constraints.length; i++) {
+            if (constraints[i].rtcStatsPeerId) {
+                return constraints[i].rtcStatsPeerId;
+            }
+        }
+    },
     conferenceIdentifier: function(client, peerConnectionLog) {
         var constraints = getPeerConnectionConstraints(peerConnectionLog) || [];
         if (!constraints.optional) return;

--- a/test/clienttest.json
+++ b/test/clienttest.json
@@ -49,6 +49,7 @@
     "value": {"optional":
       [
         {"rtcStatsClientId": "the-clientid"},
+        {"rtcStatsPeerId": "the-peer"},
         {"rtcStatsConferenceId": "the-conferenceid"}
       ]
     }


### PR DESCRIPTION
to allow correlation of logs between SDKs and rtcstats
Integration happens as optional peerconnection constraint

fixes https://github.com/opentok/rtcstats/issues/28
