### PR TITLE
use platform from github instead of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pem": "^1.8.1",
     "pg": "^4.4.6",
     "pg-promise": "^3.2.3",
-    "platform": "^1.3.1",
+    "platform": "https://github.com/bestiejs/platform.js.git",
     "sdp": "^1.0.0",
     "uuid": "^2.0.1",
     "ws": "^1.1.1"


### PR DESCRIPTION
it looks like the platform module hasn't been published to npm for a while which resultet in ChromeOS not being detected. Lets use github instead
