### PR TITLE
move numberofinterfaces last

### DIFF
--- a/features.sql
+++ b/features.sql
@@ -91,7 +91,6 @@ CREATE TABLE features_import (
     gatheredrfc1918addressprefix16 boolean,
     gatheredrfc1918addressprefix12 boolean,
     gatheredrfc1918addressprefix10 boolean,
-    numberofinterfaces integer,
     gatheringtime integer,
     gatheringtimeturntcp integer,
     gatheringtimeturntls integer,
@@ -278,5 +277,6 @@ CREATE TABLE features_import (
     browsermajorversion integer,
     starttime bigint,
     icerestartsuccess boolean,
-    icerestartfollowedbysetremotedescription boolean
+    icerestartfollowedbysetremotedescription boolean,
+    numberofinterfaces integer
 );


### PR DESCRIPTION
fixes an issue introduced in #161 -- columns can only be added at the end of the table
