### PR TITLE
remove sendaudiorttnevergreaterzero feature

### DIFF
--- a/features.js
+++ b/features.js
@@ -1413,25 +1413,6 @@ module.exports = {
         return extractLastVideoStat(peerConnectionLog, 'nackCount');
     },
 
-    // the ssrc rtt is based on rtcp and requires audio input sent.
-    // We suspect this correlates to the getUserMediaSuccessNotReally bug.
-    sendAudioRTTNeverGreaterZero: function(client, peerConnectionLog) {
-        var value = -2;
-        for (var i = 0; i < peerConnectionLog.length; i++) {
-            if (peerConnectionLog[i].type === 'getStats') {
-                var statsReport = peerConnectionLog[i].value;
-                Object.keys(statsReport).forEach(function(id) {
-                    var report = statsReport[id];
-                    if (report.type === 'ssrc' && report.mediaType === 'audio' && report.audioInputLevel && report.googRtt) {
-                        value = parseInt(report.googRtt, 10);
-                    }
-                });
-                if (value > 0) return false;
-            }
-        }
-        return value === -1 ? true : undefined;
-    },
-
     // determine maximum number of frame size (w/h) changes in 60 second window
     framesizeChanges: function(client, peerConnectionLog) {
         var windowLength = 60 * 1000;

--- a/features.sql
+++ b/features.sql
@@ -119,7 +119,6 @@ CREATE TABLE features_import (
     remotetype character varying(255),
     sendaudiocodec character varying(255),
     sendvideocodec character varying(255),
-    sendaudiorttnevergreaterzero boolean,
     sessionduration integer,
     signalingstableatleastonce boolean,
     srtpciphersuite character varying(255),


### PR DESCRIPTION
it has been replaced by norsendingaudio and chrome 52 broke
it by not emitting stat values with -1 anymore.

DB migration:
alter table drop column sendaudiorttnevergreaterzero
