### PR TITLE
add stoptime and lifetime

### DIFF
--- a/features.js
+++ b/features.js
@@ -505,6 +505,17 @@ module.exports = {
         }
     },
 
+    // when did the session end
+    stopTime: function(client, peerConnectionLog) {
+        return new Date(peerConnectionLog[peerConnectionLog.lenght - 1].time).getTime();
+    },
+
+    // how long did the peerconnection live?
+    // not necessarily connected which is different from session duration
+    lifeTime: function(client, peerConnectionLog) {
+        return new Date(peerConnectionLog[peerConnectionLog.length - 1].time).getTime() - new Date(peerConnectionLog[0].time).getTime();
+    },
+
     // the webrtc platform type -- webkit or moz
     // TODO: edge, mobile platforms?
     browserType: function(client, peerConnectionLog) {

--- a/features.sql
+++ b/features.sql
@@ -278,5 +278,7 @@ CREATE TABLE features_import (
     icerestartfollowedbyrelaycandidate boolean,
     setlocaldescriptionfailure character varying(255),
     setremotedescriptionfailure character varying(255),
-    addicecandidatefailure character varying(255)
+    addicecandidatefailure character varying(255),
+    stoptime bigint,
+    lifetime integer
 );


### PR DESCRIPTION
i needed something to express the lifetime of a peerconnection when its not connection (in which case sessionduration will not be set).

Arguably, lifetime can be calculated as starttime - stoptime but a little redundancy doesn't hurt.
