### PR TITLE
obfuscator: obfuscate all ipv6 addresses

### DIFF
--- a/obfuscator.js
+++ b/obfuscator.js
@@ -4,7 +4,7 @@ var SDPUtils = require('sdp');
 
 // obfuscate ip, keeping address family intact.
 function obfuscateIP(ip) {
-    if (ip.indexOf('[') === 0) { // IPv6
+    if (ip.indexOf('[') === 0 || ip.indexOf(':') !== -1) { // IPv6
         return '::1';
     }
     var parts = ip.split('.');


### PR DESCRIPTION
the '[' was only working for chrome-getStats.
Throwing away less information similar to the "first three octets"
ipv4 strategy would be good but we can fix that later.