### PR TITLE
features: sessionduration is undefined when not connected

### DIFF
--- a/features.js
+++ b/features.js
@@ -1224,7 +1224,6 @@ module.exports = {
                 return endTime - startTime;
             }
         }
-        return -1;
     },
 
     // determine media types used in session.


### PR DESCRIPTION
this changes sessionduration to return undefined when the client did not connect.
This should make SUM statements easier to write (or more accurate) since one
does not need to take into account the -1 value returned previously.

updating a table is fairly easy:
```
update features_permanent set sessionduration = null where sessionduration = -1;
```