### PR TITLE
obfuscate candidate ips again

### DIFF
--- a/obfuscator.js
+++ b/obfuscator.js
@@ -24,6 +24,7 @@ function obfuscateCandidate(candidate) {
     const cand = SDPUtils.parseCandidate(candidate);
     if (cand.type !== 'relay') {
         cand.ip = obfuscateIP(cand.ip);
+        cand.address = obfuscateIP(cand.address);
     }
     if (cand.relatedAddress) {
         cand.relatedAddress = obfuscateIP(cand.relatedAddress);


### PR DESCRIPTION
this was broken due to the update to sdp 2.x which parses and prefers .address instead of .ip