### PR TITLE
handle gum-only connections again

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -66,6 +66,13 @@ function generateFeatures(url, client, clientid) {
             }
         }
     });
+    if (Object.keys(client.peerConnections).length === 0) {
+        // we only have GUM and potentially GUM errors.
+        if (canUseProcessSend && isProduction) {
+            process.send({url, clientid, connid: '', clientFeatures});
+        }
+    }
+
     Object.keys(client.peerConnections).forEach(connid => {
         if (connid === 'null') return; // ignore the null connid
         const conn = client.peerConnections[connid];


### PR DESCRIPTION
otherwise GUM errors without peerconnections will never show up