### PR TITLE
extract: dont convert bool to 0/1

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -11,8 +11,10 @@ function capitalize(str) {
 function safeFeature(feature) {
     if (typeof feature === 'number' && isNaN(feature)) feature = -1;
     if (typeof feature === 'number' && !isFinite(feature)) feature = -2;
+    /*
     if (feature === false) feature = 0;
     if (feature === true) feature = 1;
+    */
 
     return feature;
 }


### PR DESCRIPTION
ref #279
do not convert booleans to 0/1. This was done for redshift but breaks bigquery when trying to load files.