### PR TITLE
move file reading to s3 storage object

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,17 +67,15 @@ class ProcessQueue {
             }
             if (this.numProc < 0) this.numProc = 0;
             if (this.numProc < this.maxProc) process.nextTick(this.process.bind(this));
-            fs.readFile(tempPath + '/' + clientid, {encoding: 'utf-8'}, (err, data) => {
-                if (err) {
-                    console.error('Could not open file for store upload', err);
-                    return;
-                }
-                // remove the file
-                fs.unlink(tempPath + '/' + clientid, () => {
-                    // we're good...
-                });
-                store.put(clientid, data);
-            });
+            const path = tempPath + '/' + clientid;
+            store.put(clientid, path);
+                .then(() => {
+                    fs.unlink(path, () => {}));
+                })
+                .catch((err) => {
+                    console.error('Error storing', path, err);
+                    fs.unlink(path, () => {}));
+                })
         });
         p.on('message', (msg) => {
             const {url, clientid, connid, clientFeatures, connectionFeatures, streamFeatures} = msg;


### PR DESCRIPTION
Moves the file reading to the s3 storage object since the GCP bucket API can only upload
based on local filename, not (easily) string contents