### PR TITLE
add support for uploading to gcp

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -14,6 +14,9 @@ firehose:
     region:
     stream:
 
+gcp:
+    bucket:
+
 appenders:
     - type: file
       layout:

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -14,6 +14,9 @@ firehose:
     region:
     stream:
 
+gcp:
+    bucket:
+
 appenders:
     - type: file
       layout:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/opentok/rtcstats-server#readme",
   "dependencies": {
+    "@google-cloud/storage": "^4.1.3",
     "aws-sdk": "^2.441.0",
     "bluebird": "^3.3.1",
     "config": "^1.17.1",

--- a/store/gcp.js
+++ b/store/gcp.js
@@ -1,0 +1,39 @@
+const zlib = require('zlib');
+const fs = require('fs');
+
+const {Storage} = require('@google-cloud/storage');
+
+module.exports = function(config) {
+  const {bucket} = config.gcp;
+  const configured = !!bucket;
+  const storage = new Storage();
+
+  return {
+    put: function(key, filename) {
+      return new Promise((resolve, reject) => {
+        if (!configured) {
+          console.log('no bucket configured for storage');
+          return resolve(); // not an error.
+        }
+        return storage.bucket(bucket).upload(key, {gzip: true});
+      });
+    },
+  };
+}
+
+if (require.main === module) {
+    // For manual testing of the upload
+    if (process.argv.length !== 4) {
+        console.log('usage: node ' + process.argv[1] + ' <gcp-bucket-name> <file-to-upload>');
+    }
+    const bucket = process.argv[2];
+    const filename = process.argv[3];
+    const instance = module.exports({gcp: {bucket}});
+    instance.put(filename, filename)
+    .then(() => {
+        console.log('uploaded ' + filename + ' to ' + bucket);
+    })
+    .catch((e) => {
+        console.error(e);
+    });
+}


### PR DESCRIPTION
Ref #279
adds support for uploading to a GCP bucket instead of S3.
GCP automatically supports  gzip-ing. This was tested similar to #296
by uploading a single-byte file which results in a 22 byte gzip file in storage.