### PR TITLE
add fallback identity information

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -168,6 +168,9 @@ fs.readFile(path, {encoding: 'utf-8'}, (err, data) => {
             case 'wsconnecterror':
                 client.websocketError = data[2];
                 break;
+            case 'identity': // identity meta-information when its not possible to feed into RTCPeerConnection.
+                client.identity = data[2];
+                break;
             case 'getUserMedia':
             case 'getUserMediaOnSuccess':
             case 'getUserMediaOnFailure':

--- a/features-connection.js
+++ b/features-connection.js
@@ -144,6 +144,9 @@ module.exports = {
                 return constraints[i].rtcStatsClientId;
             }
         }
+        if (client.identity) {
+            return client.identity.user;
+        }
     },
     peerIdentifier: function(client, peerConnectionLog) {
         let constraints = getPeerConnectionConstraints(peerConnectionLog) || [];
@@ -163,6 +166,9 @@ module.exports = {
             if (constraints[i].rtcStatsConferenceId) {
                 return constraints[i].rtcStatsConferenceId;
             }
+        }
+        if (client.identity) {
+            return client.identity.conference;
         }
     },
 


### PR DESCRIPTION
if its not possible to pass extra things to the peerconnection constructor provide
a fallback way to set the client and conference ids. The rtcstats trace looks like this:

    ['identity', null, {user: 'something', conference: 'firechat'}]

where `user` is the same thing passed as rtcStatsClientIdentifier and `conference`
is the same thing passed as rtcStatsConferenceIdentifier in the non-fallback case.