### PR TITLE
add sfup2p feature

### DIFF
--- a/features-connection.js
+++ b/features-connection.js
@@ -166,6 +166,17 @@ module.exports = {
         }
     },
 
+    sfuP2P: function(client, peerConnectionLog) {
+        let constraints = getPeerConnectionConstraints(peerConnectionLog) || [];
+        if (!constraints.optional) return;
+        constraints = constraints.optional;
+        for (let i = 0; i < constraints.length; i++) {
+            if (constraints[i].rtcStatsSFUP2P) {
+                return constraints[i].rtcStatsSFUP2P;
+            }
+        }
+    },
+
     // when did the session start
     startTime: function(client, peerConnectionLog) {
         for (let i = 0; i < peerConnectionLog.length; i++) {


### PR DESCRIPTION
in order to tag connections which utilize p2p as an alternative to a 1:1-sfu
clients need to set the optional rtcStatsSFUP2P constraint to true when using those