### PR TITLE
Skip last IP in X-Forwarded-For header

### DIFF
--- a/app.js
+++ b/app.js
@@ -202,13 +202,17 @@ function setupWebSocketsServer(server) {
 
         const forwardedFor = upgradeReq.headers['x-forwarded-for'];
         if (forwardedFor) {
-            const publicIPs = [];
-            forwardedFor.split(',').forEach(ip => {
+            const forwardedIPs = forwardedFor.split(',');
+            if (config.server.skipLoadBalancerIp) {
+                forwardedIPs.pop();
+            }
+            const obfuscatedIPs = forwardedIPs.map(ip => {
                 const publicIP = ['publicIP', null, ip.trim()];
                 obfuscate(publicIP);
-                publicIPs.push(publicIP[2]);
+                return publicIP[2];
             });
-            const publicIP = ['publicIP', null, publicIPs, Date.now()];
+
+            const publicIP = ['publicIP', null, obfuscatedIPs, Date.now()];
             tempStream.write(JSON.stringify(publicIP) + '\n');
         } else {
             const { remoteAddress } = upgradeReq.connection;

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,9 @@
 server:
     port: 3000
     metrics:
+    # Set to true if you've a LB in front of RTCStats and you are obtaining 
+    # its IP address as part of the X-Forwarded-For header
+    skipLoadBalancerIp: false
 
 s3:
     accessKeyId:

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,6 +1,9 @@
 server:
     port: 3000
     metrics:
+    # Set to true if you've a LB in front of RTCStats and you are obtaining 
+    # its IP address as part of the X-Forwarded-For header
+    skipLoadBalancerIp: false
 
 s3:
     accessKeyId:


### PR DESCRIPTION
Depending on your deployment, it may happen that the Load Balancer is including itself in the `X-Forwarded-For` header (e.g. in GCP)

We're giving the option to skip the last IP added to the header (false by default).