### PR TITLE
Make firehose failures logging less noisy but higher level

### DIFF
--- a/database/redshift-firehose.js
+++ b/database/redshift-firehose.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
           },
         }, (err) => {
           if (err) {
-            logger.info("Error firehosing data: %s - %s", err, JSON.stringify(lower(item)));
+            logger.error("Error firehosing data: %s", err);
           }
         });
       }


### PR DESCRIPTION
When Kinesis is not able to accept more records because of throtelling we generate many errors with very verbose and useless information.