### PR TITLE
Add basic artillery config file

### DIFF
--- a/artillery.config
+++ b/artillery.config
@@ -1,0 +1,13 @@
+config:
+  target: "ws://localhost:3000"
+  phases:
+    - duration: 300
+      arrivalRate: 50
+    - duration: 300
+      arrivalRate: 0
+scenarios:
+  - engine: "ws"
+    flow:
+      - send: "{}"
+      - think: 500
+


### PR DESCRIPTION
I just used artillery for a simple load testing of rtcstats servers.    

It can be run with: 
`artillery run artillery.config` 

And we could add more complex scenarios with real rtcstats data.

Hope it helps somebody else.