### PR TITLE
Add listener for websockets error events

### DIFF
--- a/app.js
+++ b/app.js
@@ -268,6 +268,10 @@ function setupWebSocketsServer(server) {
             }
         });
 
+        client.on('error', e => {
+            logger.error('Websocket error: %s', e);
+        });
+
         client.on('close', () => {
             connected.dec();
             tempStream.write(JSON.stringify(['close', null, null, Date.now()]));


### PR DESCRIPTION
When 'error' event is not catched it will stop the process.   This is happening in production some times with invalid websocket frames:  `Invalid WebSocket frame: RSV1 must be clear`

Test Plan:
- No known way to test it but at least test still works after this change.