### PR TITLE
bigquery: Use streaming API

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -23,6 +23,7 @@ gcp:
     table:
     maxFlushTime:
     bufferSize:
+    streaming: true
 
 github:
     client_id: GITHUB_CLIENT_ID

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -23,6 +23,7 @@ gcp:
     table:
     maxFlushTime:
     bufferSize:
+    streaming: true
 
 github:
     client_id: GITHUB_CLIENT_ID


### PR DESCRIPTION
Removes the need of BigQuery records buffering in a local file for 5 minutes.
The bigquery.load() API has a rate limit of "Load jobs per table per day — 1,500 (including failures)"
The bigquery.insert() (streaming) API does not have such rate limit but it costs: "$0.010 per 200 MB"

See: 
https://cloud.google.com/bigquery/streaming-data-into-bigquery
https://cloud.google.com/bigquery/quotas#streaming_inserts
https://cloud.google.com/bigquery/pricing#streaming_pricing